### PR TITLE
Humble Office refactor for a humble guy.

### DIFF
--- a/src/main/java/data/ExampleOffice.java
+++ b/src/main/java/data/ExampleOffice.java
@@ -1,0 +1,12 @@
+package data;
+
+import gearth.extensions.parsers.HGender;
+
+public class ExampleOffice extends OfficeData {
+    public ExampleOffice(int roomId, int groupId, String mottoTag) {
+        super(roomId, groupId, mottoTag);
+
+        this.appendFigure(HGender.Male, "ca-1813-0.sh-300-64.ch-225-73.lg-285-64.hd-180-1");
+        this.appendFigure(HGender.Female, "ca-1813-0.sh-907-64.hd-600-1.lg-715-64.hr-515-33.ch-880-73");
+    }
+}

--- a/src/main/java/data/OfficeData.java
+++ b/src/main/java/data/OfficeData.java
@@ -1,0 +1,39 @@
+package data;
+
+import gearth.extensions.parsers.HGender;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OfficeData {
+    private int roomId;
+    private int groupId;
+    private String mottoTag;
+    private Map<HGender, String> figures = new HashMap<>();
+
+    public OfficeData(int roomId, int groupId, String mottoTag) {
+        this.roomId = roomId;
+        this.groupId = groupId;
+        this.mottoTag = mottoTag;
+    }
+
+    public int getRoomId() {
+        return roomId;
+    }
+
+    public int getGroupId() {
+        return groupId;
+    }
+
+    public String getMottoTag() {
+        return mottoTag;
+    }
+
+    public String getFigureByGender(HGender gender) {
+        return figures.getOrDefault(gender, "");
+    }
+
+    public void appendFigure(HGender gender, String figure) {
+        this.figures.putIfAbsent(gender, figure);
+    }
+}


### PR DESCRIPTION
Generify the process of handling the room join and create a template for Offices.

- The offices are declared on the initialisation of the extension (roomId, groupId, motto).
- Each office class will append the look for each gender (see ExampleOffice).